### PR TITLE
Wrong header access path

### DIFF
--- a/modules/ROOT/pages/apikit-4-get-header-task.adoc
+++ b/modules/ROOT/pages/apikit-4-get-header-task.adoc
@@ -24,7 +24,7 @@ ns ns0 http://mulesoft.org/tshirt-service
            orderId: "I got a request from "
            ++ payload.body.ns0#OrderTshirt.name
            ++ " using the following auth header"
-           ++ payload.headers.header.ns0#AuthenticationHeader.apiKey
+           ++ payload.headers.AuthenticationHeader.ns0#AuthenticationHeader.apiKey
         }
     } write "application/xml"
 }


### PR DESCRIPTION
The apiKey is not located at:
payload.headers.header.ns0#AuthenticationHeader.apiKey

The correct way is:
payload.headers.AuthenticationHeader.ns0#AuthenticationHeader.apiKey

Feel free to convert to "dw" to check this out