### PR TITLE
Update WSDL from Apikit Mule 4 example

### DIFF
--- a/modules/ROOT/pages/apikit-4-update-wsdl-task.adoc
+++ b/modules/ROOT/pages/apikit-4-update-wsdl-task.adoc
@@ -7,9 +7,9 @@ In this procedure, you regenerate SOAP flows. After modifying a WSDL, such as ad
 
 To update a WSDL file:
 
-. Download `+https://docs.mulesoft.com/apikit/v/4.x/_attachments/tshirt-modified.wsdl+`.
+. Modify the original WSDL or download the following example `+https://github.com/mulesoft/mulesoft-docs/blob/master/api-manager/v/1.x/_attachments/tshirt-modified.wsdl+`.
 . Copy the entire contents of the downloaded file.
-. In Studio, right-click src/main/resources/api/tshirt2.wsdl, and select Open With > Test Editor.
+. In Studio, right-click src/main/resources/api/tshirt2.wsdl, and select Open With > Text Editor.
 . Replace the contents in tshirt2.wsdl with the clipboard contents.
 +
 . In Package Explorer, right-click src/main/resources/api/tshirt2.wsdl and select Mule > Generate Flows From WSDL.


### PR DESCRIPTION
The WSDL does not exist and "test editor" to "text editor"
I recover an old WSDL modified from Mule 3 example