### PR TITLE
update the URL and Steps in new project creation

### DIFF
--- a/modules/ROOT/pages/creating-an-odata-api-with-apikit.adoc
+++ b/modules/ROOT/pages/creating-an-odata-api-with-apikit.adoc
@@ -26,7 +26,7 @@ You install the APIKit OData Extension from Anypoint Studio as described in the 
 . From the *Help* menu in Studio, select *Install New Software*.
 . Click *Add...*
 . In the *Name* field, type `APIkit for ODATA Update Site`.
-. In the *Location* field, type `+http://studio.mulesoft.org/s3/apikit-for-odata/+`.
+. In the *Location* field, type `+http://studio.mulesoft.org/s4/apikit-for-odata/+`.
 . Click *OK*.
 +
 Studio displays a list of items to select.
@@ -55,7 +55,6 @@ You can download an link:{attachmentsdir}/odata.raml[example entity data model] 
 +
 . Create a new Mule project in Anypoint Studio. Click *File*, then select *New > Mule Project*.
 +
-Select the *Specify API definition file location or URL* on the New Mule Project dialog.
 . Click *Finish*
 . Copy the `odata.raml` to /src/main/resources/api in Studio project explorer.
 . In the project explorer, right-click `odata.raml` and select *Mule* > *Generate OData API from RAML Types*.


### PR DESCRIPTION
1- in https://docs.mulesoft.com/apikit/4.x/creating-an-odata-api-with-apikit#installing-the-apikit-odata-extension Step 4. is showing an old URL. It should use: http://studio.mulesoft.org/s4/apikit-for-odata/ instead 

2- in https://docs.mulesoft.com/apikit/4.x/creating-an-odata-api-with-apikit#using-the-apikit-odata-extension Step 2 mentions "Select the Specify API definition file location or URL on the New Mule Project dialog." this option is no longer available in Studio 7.4.x and is confusing. This should be removed.