### PR TITLE
Fix broken WSDL link and DW add header example

### DIFF
--- a/modules/ROOT/assets/attachments/tshirt2.wsdl
+++ b/modules/ROOT/assets/attachments/tshirt2.wsdl
@@ -1,0 +1,238 @@
+<?xml version="1.0"?>
+
+<wsdl:definitions name="TshirtService" targetNamespace="http://mulesoft.org/tshirt-service"
+    xmlns:ms="http://mulesoft.org/tshirt-service" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+
+    <wsdl:types>
+
+        <xsd:schema targetNamespace="http://mulesoft.org/tshirt-service" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:element name="ListInventory">
+                <xsd:complexType>
+                    <xsd:sequence/>
+                </xsd:complexType>
+            </xsd:element>
+            
+            <xsd:element name="ListInventoryResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="inventory" type="ms:InventoryItem" maxOccurs="unbounded"  minOccurs="1"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        
+                <xsd:complexType name="InventoryItem">
+                    <xsd:sequence>
+                        <xsd:element name="productCode" type="xsd:string" />
+                        <xsd:element name="size" type="ms:Size" />
+                        <xsd:element name="description" type="xsd:string" />
+                        <xsd:element name="count" type="xsd:integer" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            
+            <xsd:simpleType  name="Size">
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="S"/>
+                    <xsd:enumeration value="M"/>
+                    <xsd:enumeration value="L"/>
+                    <xsd:enumeration value="XL"/>
+                    <xsd:enumeration value="XXL"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+            
+            <xsd:element name="OrderTshirt">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="size" type="ms:Size" />
+                        <xsd:element name="email" type="xsd:string" />
+                        <xsd:element name="name" type="xsd:string" />
+                        <xsd:element name="address1" type="xsd:string" />
+                        <xsd:element name="address2" type="xsd:string" />
+                        <xsd:element name="city" type="xsd:string" />
+                        <xsd:element name="stateOrProvince" type="xsd:string" />
+                        <xsd:element name="postalCode" type="xsd:string" />
+                        <xsd:element name="country" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="OrderTshirtResponse">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="orderId" type="xsd:string" />
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="TrackOrder">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="email" type="xsd:string" />
+                        <xsd:element name="orderId" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            
+            <xsd:element name="TrackOrderResponse">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="orderId" type="xsd:string" />
+                        <xsd:element name="status" type="xsd:string" />
+                        <xsd:element name="size" type="ms:Size" />
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            
+            <xsd:element name="AuthenticationHeader">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="apiKey" type="xsd:string" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            
+            <xsd:element name="APIUsageInformation">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="apiCallsRemaining" type="xsd:integer" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            
+            <xsd:element name="TshirtFault">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="errorrStuff" type="xsd:integer" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="OrderTshirt">
+        <wsdl:part name="body" element="ms:OrderTshirt" />
+    </wsdl:message>
+
+    <wsdl:message name="OrderTshirtResponse">
+        <wsdl:part name="body" element="ms:OrderTshirtResponse" />
+    </wsdl:message>
+
+    <wsdl:message name="ListInventory">
+        <wsdl:part name="body" element="ms:ListInventory" />
+    </wsdl:message>
+
+    <wsdl:message name="ListInventoryResponse">
+        <wsdl:part name="body" element="ms:ListInventoryResponse" />
+    </wsdl:message>
+
+    <wsdl:message name="TrackOrder">
+        <wsdl:part name="body" element="ms:TrackOrder" />
+    </wsdl:message>
+
+    <wsdl:message name="TrackOrderResponse">
+        <wsdl:part name="body" element="ms:TrackOrderResponse" />
+    </wsdl:message>
+
+    <wsdl:message name="TshirtFault">
+        <wsdl:part name="fault" element="ms:TshirtFault" />
+    </wsdl:message>
+    
+    <wsdl:message name="APIUsageInformation">
+        <wsdl:part name="header" element="ms:APIUsageInformation" />
+    </wsdl:message>
+
+    <wsdl:message name="AuthenticationHeader">
+        <wsdl:part name="header" element="ms:AuthenticationHeader" />
+    </wsdl:message>
+
+    <!-- wsdl:portType describes messages in an operation -->
+    <wsdl:portType name="TshirtServicePortType">
+
+        <wsdl:operation name="OrderTshirt">
+            <wsdl:input message="ms:OrderTshirt" />
+            <wsdl:output message="ms:OrderTshirtResponse" />
+            <wsdl:fault name="TshirtFault" message="ms:TshirtFault" />
+        </wsdl:operation>
+        
+        <wsdl:operation name="ListInventory">
+            <wsdl:input message="ms:ListInventory" />
+            <wsdl:output message="ms:ListInventoryResponse" />
+            <wsdl:fault name="TshirtFault" message="ms:TshirtFault" />
+        </wsdl:operation>
+        
+        <wsdl:operation name="TrackOrder">
+            <wsdl:input message="ms:TrackOrder" />
+            <wsdl:output message="ms:TrackOrderResponse" />
+            <wsdl:fault name="TshirtFault" message="ms:TshirtFault" />
+        </wsdl:operation>        
+    </wsdl:portType>
+
+    <wsdl:binding name="TshirtServiceSoapBinding" type="ms:TshirtServicePortType">
+
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+
+        <wsdl:operation name="OrderTshirt">
+
+            <soap:operation soapAction="http://mulesoft.org/tshirt-service/order-tshirt" />
+
+            <wsdl:input>
+                <soap:body use="literal" namespace="http://mulesoft.org/tshirt-service" />
+                <soap:header use="literal" part="header" message="ms:AuthenticationHeader"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" namespace="http://mulesoft.org/tshirt-service" />
+                <soap:header use="literal" part="header" message="ms:APIUsageInformation"/>
+            </wsdl:output>
+            <wsdl:fault name="TshirtFault">
+                <soap:body use="literal" namespace="http://mulesoft.org/tshirt-service" />
+                <soap:header use="literal" part="header" message="ms:APIUsageInformation"/>
+            </wsdl:fault>
+            
+        </wsdl:operation>
+        
+        <wsdl:operation name="ListInventory">
+
+            <soap:operation soapAction="http://mulesoft.org/tshirt-service/list-inventory" />
+
+            <wsdl:input>
+                <soap:body use="literal" namespace="http://mulesoft.org/tshirt-service" />
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" namespace="http://mulesoft.org/tshirt-service" />
+            </wsdl:output>
+            <wsdl:fault name="TshirtFault">
+                <soap:body use="literal" namespace="http://mulesoft.org/tshirt-service" />
+            </wsdl:fault>
+        </wsdl:operation>
+        
+        <wsdl:operation name="TrackOrder">
+
+            <soap:operation soapAction="http://mulesoft.org/tshirt-service/track-order" />
+
+            <wsdl:input>
+                <soap:body use="literal" namespace="http://mulesoft.org/tshirt-service" />
+                <soap:header use="literal" part="header" message="ms:AuthenticationHeader"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal" namespace="http://mulesoft.org/tshirt-service" />
+                <soap:header use="literal" part="header" message="ms:APIUsageInformation"/>
+            </wsdl:output>
+            <wsdl:fault name="TshirtFault">
+                <soap:body use="literal" namespace="http://mulesoft.org/tshirt-service" />
+            </wsdl:fault>
+        </wsdl:operation>        
+    </wsdl:binding>
+
+    <wsdl:service name="TshirtService">
+        <wsdl:documentation></wsdl:documentation>
+
+        <!-- connect it to the binding "EndorsementSearchSoapBinding" above -->
+        <wsdl:port name="TshirtServicePort" binding="ms:TshirtServiceSoapBinding">
+
+            <!-- give the binding an network address -->
+            <soap:address location="http://localhost:8088/tshirtService" />
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/modules/ROOT/pages/apikit-set-header-task.adoc
+++ b/modules/ROOT/pages/apikit-set-header-task.adoc
@@ -3,41 +3,81 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-In this procedure, you add header information to the outbound response that complies with the WSDL. Header information that complies with the WSDL document is called APIUsageInformation.
+Using APIkit you can set headers to your application's response based on the WSDL declarations.
 
-. In Studio, open the tshirt2.wsdl in `src/main/wsdl` and scroll to APIUsageInformation element, which is the element expected by the contract. Copy the name of the element to the clipboard.
-. On the canvas, select Transform message in the `OrderTshirt:/TshirtService/TshirtServicePort/api-config` flow, and in the properties editor, click Add New Target:
+To follow this example, you must have downloaded the `tshirt2.wsdl` API definition, and created a Mule application based on it. +
+See xref:apikit-soap-prerequisites-task.adoc[Prerequisites for Using APIkit for Soap] and xref:apikit-soap-project-task.adoc[Create an APIkit for SOAP Project] for more information.
+
+In this example, you add the `APIUsageInformation` header to the response of your application:
+
+. In Studio, open the `tshirt2.wsdl` in `src/main/resources/api` and scroll to `APIUsageInformation` element, which is the element expected by the contract.
+
+. On the canvas, select the Transform Message component on the `OrderTshirt:/soapkit-config` flow.
+. In the existing Dataweave code:
 +
-image::apikit-for-soap-3005f.png[height=440,width=700]
-+
-. Select Property instead of Variable from the drop-down.
-. In Variable Name, paste the contents of the clipboard, and add *soap.* as a prefix. or type *soap.APIUsageInformation*.
-+
-The complete variable name looks like this:
-+
-soap.APIUsageInformation
-+
-. Click OK.
-. Double-click apiCallsRemaining: _Integer_.
-+
-image::apikit-for-soap-41732.png[height=440,width=700]
-+
-Double-clicking apiCallsRemaining: _Integer_ adds `APIUsageInformation: { apiCallsRemaining: null }` to the DataWeave code for the outbound property:
-+
-[source,raml,linenums]
+[source,linenums]
 ----
-%dw 1.0
-%output application/xml
-%namespace ns0 http://mulesoft.org/tshirt-service
----
 {
-  ns0#APIUsageInformation: {
-    apiCallsRemaining: null
-  }
+	body : {
+		ns0#OrderTshirtResponse: {
+			orderId: "I got a request from "
+			++ payload.body.ns0#OrderTshirt.name
+			++ " using the following auth header "
+			++ (payload.headers["AuthenticationHeader"].ns0#AuthenticationHeader.apiKey default "")
+		}
+	} write "application/xml"
 }
 ----
 +
-. Change null to *10*.
+Add the header declaration to add `APIUsageInformation`:
++
+[source,linenums]
+----
+{
+	body : {
+		ns0#OrderTshirtResponse: {
+			orderId: "I got a request from "
+			++ payload.body.ns0#OrderTshirt.name
+			++ " using the following auth header "
+			++ (payload.headers["AuthenticationHeader"].ns0#AuthenticationHeader.apiKey default "")
+		}
+	} write "application/xml",
+
+	headers: { //<1>
+		header: {
+			ns0#APIUsageInformation: {
+			}
+		} write "application/xml"
+	}
+
+}
+----
+<1> This piece of Dataweave code adds headers to the produced output in the Transform Message component.
+. Add the `apiCallsRemaining` header to the `APIUsageInformation` element:
++
+[code,linenums]
+----
+{
+	body : {
+		ns0#OrderTshirtResponse: {
+			orderId: "I got a request from "
+			++ payload.body.ns0#OrderTshirt.name
+			++ " using the following auth header "
+			++ (payload.headers["AuthenticationHeader"].ns0#AuthenticationHeader.apiKey default "")
+		}
+	} write "application/xml",
+
+	headers: {
+		header: {
+			ns0#APIUsageInformation: {
+				apiCallsRemaining: 10 //<1>
+			}
+		} write "application/xml"
+	}
+
+}
+----
+<1> This example sets `apiCallsRemaining` to `10`.
 . Save and rerun the project.
 . In the SoapUI, execute the OrderTshirt request again. The response envelope from APIkit for SOAP is:
 +

--- a/modules/ROOT/pages/apikit-set-header-task.adoc
+++ b/modules/ROOT/pages/apikit-set-header-task.adoc
@@ -3,16 +3,16 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Using APIkit you can set headers to your application's response based on the WSDL declarations.
+Use APIkit to set headers to your application's response based on the WSDL declarations.
 
-To follow this example, you must have downloaded the `tshirt2.wsdl` API definition, and created a Mule application based on it. +
+To follow this example, you must download the `tshirt2.wsdl` API definition, and create a Mule application based on it. +
 See xref:apikit-soap-prerequisites-task.adoc[Prerequisites for Using APIkit for Soap] and xref:apikit-soap-project-task.adoc[Create an APIkit for SOAP Project] for more information.
 
 In this example, you add the `APIUsageInformation` header to the response of your application:
 
 . In Studio, open the `tshirt2.wsdl` in `src/main/resources/api` and scroll to `APIUsageInformation` element, which is the element expected by the contract.
 
-. On the canvas, select the Transform Message component on the `OrderTshirt:/soapkit-config` flow.
+. On the canvas, select the Transform Message component in the `OrderTshirt:/soapkit-config` flow.
 . In the existing Dataweave code:
 +
 [source,linenums]
@@ -29,7 +29,7 @@ In this example, you add the `APIUsageInformation` header to the response of you
 }
 ----
 +
-Add the header declaration to add `APIUsageInformation`:
+Add the declaration to add the `APIUsageInformation` header:
 +
 [source,linenums]
 ----

--- a/modules/ROOT/pages/apikit-soap-prerequisites-task.adoc
+++ b/modules/ROOT/pages/apikit-soap-prerequisites-task.adoc
@@ -1,23 +1,17 @@
-= To Meet Prerequisites for Using APIkit for Soap
+= Prerequisites for Using APIkit for Soap (Mule 3)
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-This procedure describes how to set up the development environment for creating a WSDL-based API using APIkit
+This procedure describes how to set up the development environment for creating a WSDL-based API using APIkit.
 
-. Check that you are using a version of Studio that includes the Anypoint APIkit SOAP Extension:
-Help > Installation Details.
-+
-If not, install Studio 6.0 or later.
-+
-. Download the SoapUI client.
-+
-SoapUI Client site: `+https://www.soapui.org/downloads/soapui.html+`
-+
-. Download a WSDL file. For this workflow, download the example WSDL tshirt2.wsdl.
-+
-WSDL file: `+https://docs.mulesoft.com/apikit/v/3.x/_attachments/tshirt2.wsdl+`
+. Check that you are using Studio 6.
+. Download a SoapUI client. +
+For example, https://www.soapui.org/downloads/soapui.html[SoapUI].
+. Download or obtain the URL for a WSDL file. +
+For this workflow, download the link:{attachmentsdir}/tshirt2.wsdl[WSDL tshirt2.wsdl] example.
+
 
 == See Also
 
-XML code for the completed API: `+https://docs.mulesoft.com/apikit/_attachments/apikit-for-soap-tutorial.xml+`
+* xref:apikit-soap-project-task.adoc[Create an APIkit for SOAP Project]

--- a/modules/ROOT/pages/apikit-soap-prerequisites-task.adoc
+++ b/modules/ROOT/pages/apikit-soap-prerequisites-task.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 This procedure describes how to set up the development environment for creating a WSDL-based API using APIkit.
 
-. Check that you are using Studio 6.
+. Verify that you are using Studio 6.
 . Download a SoapUI client. +
 For example, https://www.soapui.org/downloads/soapui.html[SoapUI].
 . Download or obtain the URL for a WSDL file. +


### PR DESCRIPTION
This PR fixes a broken attachment link and brings the changes from https://github.com/mulesoft/docs-apikit/pull/46 to v3.x