### PR TITLE
Use current mule version for apikit

### DIFF
--- a/modules/ROOT/pages/apikit-reference.adoc
+++ b/modules/ROOT/pages/apikit-reference.adoc
@@ -19,7 +19,8 @@ Also included is a description of elements and attributes.
 <dependency>
   <groupId>org.mule.modules</groupId>
   <artifactId>mule-module-apikit</artifactId>
-  <version>3.8.1</version>
+  <version>${mule.version}</version>
+  <scope>provided</scope>
 </dependency>
 ----
 


### PR DESCRIPTION
Since Mule 3.8.0 APIKit in provided with Mule so the pom should use the same version as the target runtime and declare it as provided.