### PR TITLE
[W-10592565] new callout list syntax + fix typos

### DIFF
--- a/modules/ROOT/pages/apikit-4-soap-project-task.adoc
+++ b/modules/ROOT/pages/apikit-4-soap-project-task.adoc
@@ -11,13 +11,16 @@ Before proceeding, ensure that you meet the xref:apikit-4-soap-prerequisites-tas
 . Under the File menu, select *New* > *Mule Project*.
 +
 image::create-new-mule-project-soap.png["New Mule project window highlighting the project-name field, the runtime engine, the from design center or local files tab, and the expand icon for browsing files."]
-<1> In *Project Name*, enter a name for the project. +
-For example, _soap-implementation_.
-<1> Select the Mule runtime engine version. +
-For example, `Mule Server 4.2.2 EE`.
-<1> Under *API Specification*, select the  *From Design Center or Local Files* tab.
-<1> Select the expand icon: image:expand-icon.png[30,35] and select *Browse files...*.
 
+[calloutlist]
+. In *Project Name*, enter a name for the project. +
+For example, _soap-implementation_.
+. Select the Mule runtime engine version. +
+For example, `Mule Server 4.2.2 EE`.
+. Under *API Specification*, select the  *From Design Center or Local Files* tab.
+. Select the expand icon: image:expand-icon.png[30,35] and select *Browse files...*.
+
+[start=2]
 . Select a service and port from the drop-down menus or accept the defaults. For this example, accept the defaults: Select `TshirtService` and `TshirtServicePort`.
 +
 image::create-apikit-soap-project.png["API specification window highlights the service and the port from the drop-down menus."]

--- a/modules/ROOT/pages/creating-an-odata-api-with-apikit.adoc
+++ b/modules/ROOT/pages/creating-an-odata-api-with-apikit.adoc
@@ -31,10 +31,13 @@ image::generate-odata.png["Window highlights the full path that was previously m
 . The OData extension generates the necessary files for your OData API implementation:
 +
 image::list-of-odata-files.png["The three files are highlighted in the tree: api.xml in the Mule folder, and api.raml and odatalibrary.raml files in the resource folder."]
-+
-<1> The Mule configuration file with the flows for the API implementation
-<1> The generated RAML definition
-<1> The generated RAML libraries
+
+[calloutlist]
+. The Mule configuration file with the flows for the API implementation
+. The generated RAML definition
+. The generated RAML libraries
+
+[start=7]
 . Add the necessary logic for your API implementation in the flows.
 
 == OData MySQL Example

--- a/modules/ROOT/pages/creating-an-odatav4-api-with-apikit.adoc
+++ b/modules/ROOT/pages/creating-an-odatav4-api-with-apikit.adoc
@@ -63,11 +63,11 @@ For example, `odata-metadata.csdl.xml`:
 --
 +
 <1> `EntityType` defines the type and its properties
-<1> `key` defines which property or set of properties is the key for the entity. +
+<2> `key` defines which property or set of properties is the key for the entity. +
 For example, the entity set `Orders` is composed of two keys `OrderID` and `ShipName`.
-<1> `EntityContainer` defines the sets of exposed entities. +
+<3> `EntityContainer` defines the sets of exposed entities. +
 In this example, `Orders` and `Customers`.
-<1> `EntitySet` contains a name and EntityType. +
+<4> `EntitySet` contains a name and EntityType. +
 Both must be defined in the `schema` namespace.
 . In the Package Explorer view, right-click your *odata-metadata.csdl.xml* file > *Generate Mule OData 4 API*:
 +
@@ -76,9 +76,10 @@ image::generate-odata-v4-api.png["Window displays the previously mentioned path 
 +
 image::generated-odata-4-flow.png["The three flows created from the csdl.xml metadata file are highlighted."]
 +
-<1> The main flow that receives messages and routes the operation to the correct handler.
-<1> Five flows with `GET`, `PUT`, `POST`, and `DELETE` operations for each entity.
-<1> A flow with a `GET` operation to retrieve the collection of entities.
+[calloutlist]
+. The main flow that receives messages and routes the operation to the correct handler.
+. Five flows with `GET`, `PUT`, `POST`, and `DELETE` operations for each entity.
+. A flow with a `GET` operation to retrieve the collection of entities.
 
 == Handle OData System Query Options
 


### PR DESCRIPTION
ref: [W-10592565](https://gus.lightning.force.com/a07EE00000laXx7YAE)

this PR provides a number of fixes/workarounds to reduce the number of build warnings and errors.

- use [a new extension](https://github.com/RayOffiah/asciidoctor-external-callout-js) which allows us to use the `[calloutlist]` syntax for the callouts when the numbers are embedded into images

validated via local build that the callout numbers look the same after using the new syntax.