### PR TITLE
Use HTTPS for OData Studio plugin Update Site

### DIFF
--- a/modules/ROOT/pages/apikit-4-for-odata.adoc
+++ b/modules/ROOT/pages/apikit-4-for-odata.adoc
@@ -18,8 +18,8 @@ To install APIkit for OData in Anypoint Studio:
 image::add-update-site.png["Window for installing new software with the Add button highlighted."]
 . In the *Name* field, type `APIkit for ODATA Update Site`.
 . In the *Location* field, type the URL corresponding to the OData version that you want to install
-  ** APIkit for OData 2.0: `+http://studio.mulesoft.org/s4/apikit-for-odata/+`.
-  ** APIkit for OData 4.0: `+http://studio.mulesoft.org/s4/apikit-for-odata4/+`.
+  ** APIkit for OData 2.0: `+https://studio.mulesoft.org/s4/apikit-for-odata/+`.
+  ** APIkit for OData 4.0: `+https://studio.mulesoft.org/s4/apikit-for-odata4/+`.
 . Click *Add*.
 +
 image::add-repository-odata.png["Window for adding a repository with the Add button and the name and location fields highlighted."]


### PR DESCRIPTION
Using HTTP instead of HTTPS throws the following error when it is tried to install them: `HTTP Server 'Service Unavailable'`.