### PR TITLE
Document Kafka limitations in error handling

### DIFF
--- a/modules/ROOT/pages/apikit-asyncapi-error-handling-reference.adoc
+++ b/modules/ROOT/pages/apikit-asyncapi-error-handling-reference.adoc
@@ -25,3 +25,7 @@ APIkit for AsyncAPI defines the following error types:
 == APIkit for AsyncAPI Error Handling
 
 APIkit for AsyncAPI scaffolder generates no error-handling code.
+
+=== Limitations of Kafka 
+
+Since the Source Message Listener, with content validation enabled, does not throw an exception, we cannot implement the DLQ/DLT pattern for Kafka. In this model, the consumer is responsible for routing invalid messages to DLQ/DLT topics.


### PR DESCRIPTION
Added limitations section for Kafka regarding error handling.

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [x] Run link checker to check for broken xrefs
- [x] Check for orphan files
- [x] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [x] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [x] If applicable, verify that the software actually got released