### PR TITLE
docs(apikit-asyncapi): clarify that XML validation is not supported

### DIFF
--- a/modules/ROOT/pages/apikit-asyncapi-module-reference.adoc
+++ b/modules/ROOT/pages/apikit-asyncapi-module-reference.adoc
@@ -72,6 +72,9 @@ In the *Publish* operation, the payload must be JSON. The APIkit for AsyncAPI mo
 
 == Validation of Messages
 
+[NOTE]
+XML message validation is not supported. Only JSON payloads can be validated against their schemas.
+
 Unless explicitly restricted, the JSON schema validation allows omitting and adding fields. Check the message validation against the schema in the following table: 
 
 [%header%autowidth.spread]


### PR DESCRIPTION
Add an explicit NOTE at the start of the "Validation of Messages" section stating that XML message validation is not supported and that only JSON payloads are validated against schemas.

Rationale:
- Prevent confusion for users expecting XML schema validation
- Align parameter wording with actual validation capabilities

This product limitation has been confirmed in GUS ID W-16756836

# Writer's Quality Checklist

Before merging your PR, did you:

- [x] Run spell checker
- [x] Run link checker to check for broken xrefs
- [x] Check for orphan files
- [x] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [x] If applicable, verify that the software actually got released